### PR TITLE
Include .volt files for Phalcon developers

### DIFF
--- a/ftdetect/twig.vim
+++ b/ftdetect/twig.vim
@@ -3,3 +3,6 @@ autocmd BufNewFile,BufRead *.twig set filetype=twig
 
 " HTML Twig
 autocmd BufNewFile,BufRead *.html.twig set filetype=html.twig
+
+" Volt (for Phalcon Framework)
+autocmd BufNewFile,BufRead *.volt set filetype=html.twig


### PR DESCRIPTION
I don't know if I did it in the right way.

I use .volt extension (for Phalcon Framework) and it didn't work. But now it supports .volt files,
